### PR TITLE
Fix TS definition to match the code

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,16 +1,15 @@
 export type Ibnc = {
-    el(elName: string): Ibnc & string;
-    boolmod(mod: string, modValue): Ibnc & string;
-    bod(mod: string, modValue): Ibnc & string;
-    mod(mod: string, modValue?: string): Ibnc & string;
+    el(elName: string): Bnc;
+    boolmod(mod: string, modValue?: boolean): Bnc;
+    bod(mod: string, modValue?: boolean): Bnc;
+    mod(mod: string, modValue?: string): Bnc;
 }
 
 export type Bnc = Ibnc & string;
 
-declare module 'bnc' {
-    interface BncCtor {
-        new (name: string) : Bnc;
-    }
-    const bnc: BncCtor;
-    export = bnc;
+interface BncCtor {
+    new(name: string): Bnc;
 }
+
+declare const bnc: BncCtor;
+export default bnc;

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "lint": "eslint index.js"
   },
   "main": "./dist/index.js",
+  "types": "./index.d.ts",
   "engines": {
     "node": ">=6.4.0",
     "npm": ">=3.10.6"


### PR DESCRIPTION
В описании типов утверждалось, что bnc экспортирует конструктор через export assignment, в то время как в js-коде это происходит через default export. В результате использовать его напрямую из TypeScript было невозможно - корректный с точки зрения типов импорт разваливался в рантайме (или при сборке).